### PR TITLE
Add Docker support and env example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+env/
+venv/
+build/
+dist/
+*.egg-info/
+.git/
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=asuu_tracker
+# Optionally provide a full connection string instead
+# DATABASE_URL=postgresql://postgres:postgres@localhost:5432/asuu_tracker

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+env/
+venv/
+build/
+dist/
+*.egg-info/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ Visit `http://localhost:8000/docs` to view the API.
   uvicorn main:app --host 0.0.0.0 --port $PORT
   ```
 - Done 🎉
+
+### Docker
+Build the container image:
+```bash
+docker build -t asuu-legislation-tracker .
+```
+
+Run the container using your `.env` file:
+```bash
+docker run --env-file .env -p 8000:8000 asuu-legislation-tracker
+```


### PR DESCRIPTION
## Summary
- add `.env.example` for deployment environment variables
- add a basic Dockerfile with `.dockerignore`
- ignore common local files with `.gitignore`
- document Docker usage in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6865b55f53b88332ac9fe246b621eb64