### PR TITLE
Add search and filtering endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASUU Legislation Tracker Backend
 
-A FastAPI backend for tracking ASUU legislation. Includes endpoints to create, read, update, and delete legislation records.
+A FastAPI backend for tracking ASUU legislation. Includes endpoints to create, read, update, and delete legislation records. The `GET /legislation` endpoint now supports basic search and filtering.
 
 ## 🚀 Setup Instructions
 
@@ -23,6 +23,22 @@ A FastAPI backend for tracking ASUU legislation. Includes endpoints to create, r
    ```
 
 Visit `http://localhost:8000/docs` to view the API.
+
+### Filtering and Search
+
+The `GET /legislation` endpoint accepts optional query parameters:
+
+- `q` – search text matched against the title and summary
+- `type` – filter by legislation type (e.g. `Senate`, `Assembly`, `Joint`)
+- `status` – filter by current status
+
+There are also convenience routes for each type:
+
+- `GET /legislation/senate`
+- `GET /legislation/assembly`
+- `GET /legislation/joint`
+
+Each of these accepts the same `q` and `status` parameters.
 
 ### Railway Deployment
 - Link repo and provision PostgreSQL

--- a/main.py
+++ b/main.py
@@ -1,16 +1,66 @@
-from fastapi import FastAPI, Depends, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Query
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
+
+import database
 import models
 import schemas
-import database
 
 models.Base.metadata.create_all(bind=database.engine)
 
 app = FastAPI(title="ASUU Legislation Tracker API")
 
+
 @app.get("/legislation", response_model=list[schemas.Legislation])
-def list_legislation(db: Session = Depends(database.get_db)):
-    return db.query(models.Legislation).order_by(models.Legislation.introduced_date.desc()).all()
+def list_legislation(
+    *,
+    q: str | None = Query(default=None, description="Search text"),
+    type: str | None = Query(default=None, description="Filter by type"),
+    status: str | None = Query(default=None, description="Filter by status"),
+    db: Session = Depends(database.get_db),
+):
+    query = db.query(models.Legislation)
+    if q:
+        like = f"%{q}%"
+        query = query.filter(
+            or_(
+                models.Legislation.title.ilike(like),
+                models.Legislation.summary.ilike(like),
+            )
+        )
+    if type:
+        query = query.filter(models.Legislation.type == type)
+    if status:
+        query = query.filter(models.Legislation.status == status)
+    return query.order_by(models.Legislation.introduced_date.desc()).all()
+
+
+@app.get("/legislation/senate", response_model=list[schemas.Legislation])
+def list_senate_legislation(
+    q: str | None = Query(default=None, description="Search text"),
+    status: str | None = Query(default=None, description="Filter by status"),
+    db: Session = Depends(database.get_db),
+):
+    return list_legislation(q=q, type="Senate", status=status, db=db)
+
+
+@app.get("/legislation/assembly", response_model=list[schemas.Legislation])
+def list_assembly_legislation(
+    q: str | None = Query(default=None, description="Search text"),
+    status: str | None = Query(default=None, description="Filter by status"),
+    db: Session = Depends(database.get_db),
+):
+    return list_legislation(q=q, type="Assembly", status=status, db=db)
+
+
+@app.get("/legislation/joint", response_model=list[schemas.Legislation])
+def list_joint_legislation(
+    q: str | None = Query(default=None, description="Search text"),
+    status: str | None = Query(default=None, description="Filter by status"),
+    db: Session = Depends(database.get_db),
+):
+    return list_legislation(q=q, type="Joint", status=status, db=db)
+
 
 @app.get("/legislation/{item_id}", response_model=schemas.Legislation)
 def get_legislation(item_id: int, db: Session = Depends(database.get_db)):
@@ -19,16 +69,24 @@ def get_legislation(item_id: int, db: Session = Depends(database.get_db)):
         raise HTTPException(status_code=404, detail="Legislation not found")
     return item
 
+
 @app.post("/legislation", response_model=schemas.Legislation, status_code=201)
-def create_legislation(data: schemas.LegislationCreate, db: Session = Depends(database.get_db)):
+def create_legislation(
+    data: schemas.LegislationCreate, db: Session = Depends(database.get_db)
+):
     new_item = models.Legislation(**data.dict())
     db.add(new_item)
     db.commit()
     db.refresh(new_item)
     return new_item
 
+
 @app.put("/legislation/{item_id}", response_model=schemas.Legislation)
-def update_legislation(item_id: int, data: schemas.LegislationUpdate, db: Session = Depends(database.get_db)):
+def update_legislation(
+    item_id: int,
+    data: schemas.LegislationUpdate,
+    db: Session = Depends(database.get_db),
+):
     item = db.query(models.Legislation).get(item_id)
     if not item:
         raise HTTPException(status_code=404, detail="Legislation not found")
@@ -37,6 +95,7 @@ def update_legislation(item_id: int, data: schemas.LegislationUpdate, db: Sessio
     db.commit()
     db.refresh(item)
     return item
+
 
 @app.delete("/legislation/{item_id}", status_code=204)
 def delete_legislation(item_id: int, db: Session = Depends(database.get_db)):


### PR DESCRIPTION
## Summary
- implement query parameters for GET /legislation
- add dedicated endpoints for senate, assembly, and joint
- document filtering options in README

## Testing
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6865b6918b508332990a8236a42b47b1