### PR TITLE
Fix Dockerfile for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Use the PORT environment variable provided by Railway. Default to 8000 for local runs.
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
## Summary
- update Dockerfile to respect the `PORT` environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bbc81f308332bb44652f522f8ded