### PR TITLE
Add Next.js frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 dist/
 *.egg-info/
 .env
+frontend/node_modules/

--- a/README.md
+++ b/README.md
@@ -59,3 +59,23 @@ Run the container using your `.env` file:
 ```bash
 docker run --env-file .env -p 8000:8000 asuu-legislation-tracker
 ```
+
+## Next.js Frontend (Supabase & Vercel)
+A minimal frontend is provided in the `frontend/` directory. It uses Next.js with Supabase for data storage and Tailwind CSS for styling.
+
+### Setup
+1. Create a free Supabase project and add the table using `frontend/supabase_schema.sql`.
+2. Copy the Supabase URL and anon key into a `.env.local` file inside `frontend/`:
+   ```bash
+   NEXT_PUBLIC_SUPABASE_URL=your-url
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=your-key
+   ```
+3. Install dependencies and run the development server:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+4. Deploy the frontend to Vercel and add the same environment variables.
+
+This example provides basic listing and creation of legislation items and can be extended to match additional Notion features.

--- a/frontend/lib/supabaseClient.ts
+++ b/frontend/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+}
+
+module.exports = nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "asuu-legislation-tracker-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.39.6"
+  },
+  "devDependencies": {
+    "typescript": "5.4.3",
+    "tailwindcss": "3.4.1",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { supabase } from '../lib/supabaseClient'
+import '../styles/globals.css'
+
+interface Legislation {
+  id: number
+  title: string
+  type: string
+  status: string
+  introduced_date?: string
+}
+
+export default function Home() {
+  const [items, setItems] = useState<Legislation[]>([])
+
+  useEffect(() => {
+    supabase
+      .from('legislation')
+      .select('*')
+      .then(({ data }) => {
+        if (data) setItems(data)
+      })
+  }, [])
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">ASUU Legislation</h1>
+      <Link href="/new" className="text-blue-600">Add New</Link>
+      <table className="min-w-full mt-4">
+        <thead>
+          <tr>
+            <th className="text-left">Title</th>
+            <th className="text-left">Type</th>
+            <th className="text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(item => (
+            <tr key={item.id} className="border-t">
+              <td>
+                <Link href={`/legislation/${item.id}`}>{item.title}</Link>
+              </td>
+              <td>{item.type}</td>
+              <td>{item.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  )
+}

--- a/frontend/pages/legislation/[id].tsx
+++ b/frontend/pages/legislation/[id].tsx
@@ -1,0 +1,47 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { supabase } from '../../lib/supabaseClient'
+import '../../styles/globals.css'
+
+interface Legislation {
+  id: number
+  title: string
+  type: string
+  status: string
+  summary?: string
+  document_url?: string
+}
+
+export default function LegislationPage() {
+  const router = useRouter()
+  const { id } = router.query
+  const [item, setItem] = useState<Legislation | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    supabase
+      .from('legislation')
+      .select('*')
+      .eq('id', id)
+      .single()
+      .then(({ data }) => {
+        if (data) setItem(data)
+      })
+  }, [id])
+
+  if (!item) return <p className="p-4">Loading...</p>
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-2">{item.title}</h1>
+      <p>Type: {item.type}</p>
+      <p>Status: {item.status}</p>
+      {item.summary && <p className="mt-4">{item.summary}</p>}
+      {item.document_url && (
+        <p className="mt-2">
+          <a href={item.document_url} className="text-blue-600">Document</a>
+        </p>
+      )}
+    </main>
+  )
+}

--- a/frontend/pages/new.tsx
+++ b/frontend/pages/new.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { supabase } from '../lib/supabaseClient'
+import '../styles/globals.css'
+
+export default function NewLegislation() {
+  const router = useRouter()
+  const [title, setTitle] = useState('')
+  const [type, setType] = useState('Senate')
+  const [status, setStatus] = useState('Draft')
+
+  async function submit() {
+    const { error } = await supabase.from('legislation').insert({ title, type, status })
+    if (!error) router.push('/')
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">New Legislation</h1>
+      <div className="mb-2">
+        <label className="block">Title</label>
+        <input className="border p-1" value={title} onChange={e => setTitle(e.target.value)} />
+      </div>
+      <div className="mb-2">
+        <label className="block">Type</label>
+        <select className="border p-1" value={type} onChange={e => setType(e.target.value)}>
+          <option>Senate</option>
+          <option>Assembly</option>
+          <option>Joint</option>
+        </select>
+      </div>
+      <div className="mb-2">
+        <label className="block">Status</label>
+        <input className="border p-1" value={status} onChange={e => setStatus(e.target.value)} />
+      </div>
+      <button className="bg-blue-600 text-white px-2 py-1" onClick={submit}>Save</button>
+    </main>
+  )
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/supabase_schema.sql
+++ b/frontend/supabase_schema.sql
@@ -1,0 +1,10 @@
+create table if not exists public.legislation (
+  id serial primary key,
+  title text not null,
+  type varchar(50) not null,
+  status varchar(50) not null,
+  introduced_date date,
+  passed_date date,
+  summary text,
+  document_url text
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js+Supabase skeleton in `frontend/`
- document running the frontend in README
- ignore frontend `node_modules`

## Testing
- `python -m py_compile main.py database.py models.py schemas.py`
- `node -e "require('./frontend/pages/index.tsx'); console.log('ok')"` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6866012b99b08332bb9ae0c5399866c1